### PR TITLE
added ability to make the main docker daemon listen on multipe ports

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,7 +12,7 @@ provisioner:
 
 platforms:
   - name: ubuntu-14.04
-  # - name: centos-7.1
+  - name: centos-7.1
 
 suites:
   - name: master

--- a/resources/master.rb
+++ b/resources/master.rb
@@ -23,6 +23,7 @@ property :bootstrap_docker_graph, String, default: "/var/lib/docker-bootstrap"
 property :bootstrap_docker_pid, String, default: "/var/run/docker-bootstrap.pid"
 
 property :docker_host, String, default: "unix:///var/run/docker.sock"
+property :additional_hosts, Array, default: []
 
 property :etcd_version, String, default: "2.2.4"
 property :etcd_repo, String, default: "quay.io/coreos/etcd", desired_state: false
@@ -113,7 +114,7 @@ action :create do
       install_method "none"
       bip lazy { node.run_state["flannel_subnet"].chomp }
       mtu lazy { node.run_state["flannel_mtu"].chomp }
-      host docker_host
+      host (additional_hosts << docker_host)
     end
 
     docker_image "hyperkube" do

--- a/test/cookbooks/k8s_test/recipes/master.rb
+++ b/test/cookbooks/k8s_test/recipes/master.rb
@@ -11,7 +11,9 @@ end
 
 require 'kubeclient'
 
-kubernetes_master "my master"
+kubernetes_master "my master" do
+  additional_hosts ['tcp://0.0.0.0:4243']
+end
 
 kubernetes_service "nginx" do
   ports [{:protocol=>"TCP", :port=>80, :targetPort=>80}]


### PR DESCRIPTION
This will allow the main docker daemon to listen on a tcp port, which will enable the remote api. 
