### PR TITLE
Optionally allow insecure image registries

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'thom@chef.io'
 license 'apache2'
 description 'Installs/Configures kubernetes'
 long_description 'Installs/Configures kubernetes'
-version '0.1.0'
+version '0.1.1'
 
 depends "docker"
 depends "etcd"

--- a/resources/master.rb
+++ b/resources/master.rb
@@ -24,6 +24,7 @@ property :bootstrap_docker_pid, String, default: "/var/run/docker-bootstrap.pid"
 
 property :docker_host, String, default: "unix:///var/run/docker.sock"
 property :additional_hosts, Array, default: []
+property :insecure_registry, [String, nil], default: nil
 
 property :etcd_version, String, default: "2.2.4"
 property :etcd_repo, String, default: "quay.io/coreos/etcd", desired_state: false
@@ -115,6 +116,7 @@ action :create do
       bip lazy { node.run_state["flannel_subnet"].chomp }
       mtu lazy { node.run_state["flannel_mtu"].chomp }
       host (additional_hosts << docker_host)
+      insecure_registry(new_resource.insecure_registry) if new_resource.insecure_registry
     end
 
     docker_image "hyperkube" do

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -26,6 +26,7 @@ property :bootstrap_docker_graph, String, default: "/var/lib/docker-bootstrap"
 property :bootstrap_docker_pid, String, default: "/var/run/docker-bootstrap.pid"
 
 property :docker_host, String, default: "unix:///var/run/docker.sock"
+property :insecure_registry, [String, nil], default: nil
 
 property :flanneld_version, String, default: "0.5.5"
 property :flanneld_repo, String, default: "quay.io/coreos/flannel", desired_state: false
@@ -89,6 +90,7 @@ action :create do
       bip lazy { node.run_state["flannel_subnet"].chomp }
       mtu lazy { node.run_state["flannel_mtu"].chomp }
       host docker_host
+      insecure_registry(new_resource.insecure_registry) if new_resource.insecure_registry
     end
 
     docker_image "hyperkube" do

--- a/resources/node.rb
+++ b/resources/node.rb
@@ -109,7 +109,7 @@ action :create do
       network_mode "host"
       privileged true
       pid_mode "host"
-      command "/hyperkube kubelet --api-servers=http://#{master_ip}:#{master_port} --v=2 --address=0.0.0.0 --enable-server --hostname-override=#{node['ipaddress']} --cluster-dns=10.0.0.10 --cluster-domain=cluster.local"
+      command "/hyperkube kubelet --api-servers=http://#{master_ip}:#{master_port} --v=2 --address=0.0.0.0 --enable-server --hostname-override=#{node['ipaddress']} --cluster-dns=10.0.0.10 --cluster-domain=cluster.local --allow-privileged=true"
     end
 
     docker_container "proxy" do

--- a/test/cookbooks/k8s_test/recipes/master.rb
+++ b/test/cookbooks/k8s_test/recipes/master.rb
@@ -13,6 +13,7 @@ require 'kubeclient'
 
 kubernetes_master "my master" do
   additional_hosts ['tcp://0.0.0.0:4243']
+  insecure_registry 'insecure_reg.com:5000'
 end
 
 kubernetes_service "nginx" do

--- a/test/cookbooks/k8s_test/recipes/node.rb
+++ b/test/cookbooks/k8s_test/recipes/node.rb
@@ -4,4 +4,5 @@ end.run_action(:run)
 
 kubernetes_node "node 1" do
   master_ip "192.168.56.100"
+  insecure_registry 'insecure_reg.com:5000'
 end


### PR DESCRIPTION
Allow insecure image registries from master and node resources. This will let a user create pods/containers from external, insecure registries.
